### PR TITLE
Kubernetes 1.16 changes

### DIFF
--- a/helloworld/templates/deployment.yaml
+++ b/helloworld/templates/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: List
 items:
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:


### PR DESCRIPTION
With Kubernetes >=1.16 , apiVersion has changed to apps/v1